### PR TITLE
fix(dragonfly): fetch CRD via GitRepository instead of raw.githubusercontent.com

### DIFF
--- a/kubernetes/apps/storage/dragonfly/app/crd.yaml
+++ b/kubernetes/apps/storage/dragonfly/app/crd.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/refs/heads/main/gitrepository-source-v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: dragonfly-crd
+spec:
+  interval: 30m
+  url: https://github.com/dragonflydb/dragonfly-operator
+  ref:
+    tag: v1.6.1
+  ignore: |
+    # exclude
+    /*
+    # include
+    !manifests/crd.yaml
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: dragonfly-crd
+spec:
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: dragonfly-crd
+  wait: true
+  interval: 15m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/storage/dragonfly/app/kustomization.yaml
+++ b/kubernetes/apps/storage/dragonfly/app/kustomization.yaml
@@ -3,7 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  # renovate: datasource=github-releases depName=dragonflydb/dragonfly-operator
-  - https://raw.githubusercontent.com/dragonflydb/dragonfly-operator/v1.6.1/manifests/crd.yaml
+  - ./crd.yaml
   - ./helmrelease.yaml
   - ./rbac.yaml

--- a/kubernetes/apps/storage/dragonfly/ks.yaml
+++ b/kubernetes/apps/storage/dragonfly/ks.yaml
@@ -36,6 +36,8 @@ spec:
   dependsOn:
     - name: dragonfly
       namespace: storage
+    - name: dragonfly-crd
+      namespace: storage
   path: ./kubernetes/apps/storage/dragonfly/cluster
   prune: true
   sourceRef:


### PR DESCRIPTION
## What

Replaces the remote `resources:` entry pointing at `raw.githubusercontent.com` with a Flux `GitRepository` on `github.com`, plus an inline Flux `Kustomization` — the same pattern already used by `multus-crd`.

## Why

`FluxKustomizationBuildFailed` firing on the `dragonfly` Kustomization:

```
kustomize build failed: accumulating resources from
'https://raw.githubusercontent.com/dragonflydb/dragonfly-operator/v1.6.1/manifests/crd.yaml':
dial tcp [2606:50c0:8002::154]:443: connect: network is unreachable
```

This cluster has no IPv6 route, but CoreDNS forwards to `/etc/resolv.conf` with no AAAA filtering. `raw.githubusercontent.com` returns an AAAA record, kustomize-controller dials IPv6, and the fetch fails.

The trailing `404: Not Found` / `repository not found` in the alert is a red herring — it's kustomize falling back to treating the URL as a git repo after the HTTPS GET fails.

`github.com` over git/HTTPS works fine here (flux-system syncs from it; the alert itself carries `revision: refs/heads/main@sha1:d32e7408`). The broken hosts are specifically GitHub Pages and `raw.githubusercontent.com`.

## Notes for review

- **Chart/CRD version is unchanged** — still pinned to `v1.6.1`. Path `manifests/crd.yaml` verified present at that tag via the GitHub API.
- **`kustomize build` now does zero network I/O.** Fetching moves from kustomize-controller to source-controller.
- **`dragonfly-crd` added to `dragonfly-cluster`'s `dependsOn`.** The CRD was previously applied inline alongside the HelmRelease; it's now one hop further, and `dragonfly` has `wait: false`, so the `Dragonfly` CRs could otherwise race ahead of their own CRD on first reconcile.
- I swept the repo for other build-time remote fetches — **none remain**. The other `raw.githubusercontent.com` hits are all `# yaml-language-server:` schema comments, which only the editor reads.

## Context

Third alert from the same underlying IPv4-only/AAAA cause. The earlier two were `FluxHelmRepositoryFailed` on Pages-hosted `HelmRepository` sources, fixed in d32e740 and a7a0ca8 by migrating to `OCIRepository`. This closes out the last known build-time remote fetch, though it's still fixing symptoms — a CoreDNS `template ANY AAAA` block would close the class off permanently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)